### PR TITLE
Tutorial dependencies could not install properly in v3.4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ pip install git+https://github.com/CDDLeiden/DrugEx.git@master
 
 ### Optional Dependencies
 
-<<<<<<< HEAD
 **[QSPRPred](https://github.com/CDDLeiden/QSPRPred.git)** - Optional package to install if you want to use the command line interface of DrugEx, which requires the models to be serialized with this package. It is also used by some examples in the tutorial. Install DrugEx with the following command if you want these features:
 
 ```bash

--- a/tutorial/requirements.txt
+++ b/tutorial/requirements.txt
@@ -1,5 +1,5 @@
 jupyterlab
 mols2grid
 papyrus_structure_pipeline
-papyrus-scaffold-visualizer @ git+https://github.com/martin-sicho/papyrus-scaffold-visualizer.git@v0.6.0
+papyrus-scaffold-visualizer @ git+https://github.com/martin-sicho/papyrus-scaffold-visualizer.git@main
 drugex[qsprpred] @ git+https://github.com/CDDLeiden/DrugEx.git@master


### PR DESCRIPTION
This solution still needs to be tested, but there were some small issues (mainly in the tutorial dependencies). I am putting this here in case anyone runs into them before we release these fixes.