### PR TITLE
Fix SequenceRNN crash when running on CPU

### DIFF
--- a/drugex/training/generators/sequence_rnn.py
+++ b/drugex/training/generators/sequence_rnn.py
@@ -43,7 +43,10 @@ class SequenceRNN(Generator):
         -------
         None
         """
-        self.device = torch.device(f'cuda:{gpus[0]}')
+        if gpus[0] == -1:
+            self.device = torch.device('cpu')
+        else:
+            self.device = torch.device(f'cuda:{gpus[0]}')
         self.to(self.device)
         self.gpus = (gpus[0],)
 


### PR DESCRIPTION
### Summary

SequenceRNN crashes with `RuntimeError: Invalid device string: 'cuda:-1'` when instantiated on a CPU-only machine.

### Problem

`SequenceRNN.__init__` calls `self.attachToGPUs(self.gpus)` after the parent constructor sets `self.gpus =  (-1,)` for CPU. The method unconditionally builds `torch.device(f'cuda:{gpus[0]}')`, producing the invalid device `cuda: -1`.

### Fix

Branch on the GPU index before creating the device. No other generators are affecte- they use the base class `attachToGPUs` which just calls `self.to(self.device)`.

@martin-sicho